### PR TITLE
Landingpagerework

### DIFF
--- a/app/assets/stylesheets/info.scss
+++ b/app/assets/stylesheets/info.scss
@@ -82,6 +82,27 @@ body {
   margin-bottom: 10px;
 }
 
+// Container for the iframe
+.frame-holder {
+  width: 300px;
+  height: 400px;
+  margin: 0 auto;
+}
+
+// Div that goes on top of the iframes to prevent user interaction
+.frame-overlay{
+  position:absolute;
+  background: rgba(0,0,0,0);
+  width: 320px;
+  height: 420px;
+}
+
+.frame {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 /* FOOTER */
 
 .footer {

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -1,15 +1,19 @@
 class InfoController < ApplicationController
 
+  # GET /about
+  def show
+    render :layout => false
+  end
 
-    # GET /about
-    def show
-        render :layout => false
-    end
+  # Creates temporary meeting to demo the status page on the info page. Meeting is NOT saved to the db.
+  def statusdemo
+    @meeting = Meeting.new(phone_number: "asd@asd.fi", nickname: "pekka", duration: 30, created_at: Time.now, id: 666)
+    render '/meetings/show.html.erb'
+  end
 
-    # Creates temporary meeting to demo the status page on the info page. Meeting is NOT saved to the db.
-    def statusdemo
-        @meeting = Meeting.new(phone_number: "asd@asd.fi", nickname: "pekka", duration: 30, created_at: Time.now, id: 666)
-        render '/meetings/show.html.erb'
-    end
+  def creationdemo
+    @meeting = Meeting.new
+    render '/meetings/new.html.erb'
+  end
 
 end

--- a/app/controllers/info_controller.rb
+++ b/app/controllers/info_controller.rb
@@ -1,8 +1,15 @@
 class InfoController < ApplicationController
-    layout false
+
 
     # GET /about
     def show
+        render :layout => false
+    end
+
+    # Creates temporary meeting to demo the status page on the info page. Meeting is NOT saved to the db.
+    def statusdemo
+        @meeting = Meeting.new(phone_number: "asd@asd.fi", nickname: "pekka", duration: 30, created_at: Time.now, id: 666)
+        render '/meetings/show.html.erb'
     end
 
 end

--- a/app/views/info/_form.html.erb
+++ b/app/views/info/_form.html.erb
@@ -1,0 +1,1 @@
+<%= render 'meetings/form.html.erb' %>

--- a/app/views/info/about.html.erb
+++ b/app/views/info/about.html.erb
@@ -41,7 +41,7 @@
           <div>
             <div class="frame-holder">
               <div class="frame-overlay"></div>
-              <iframe scrolling="no" align="middle" class="frame" src="/meetings/new"></iframe>
+              <iframe scrolling="no" align="middle" class="frame" src="/creationdemo"></iframe>
 
             </div>
           </div>

--- a/app/views/info/about.html.erb
+++ b/app/views/info/about.html.erb
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <%= stylesheet_link_tag 'info' %>
-  <title>Seksityö Landing Page</title>
+  <title>Landing Page</title>
 </head>
 <body>
   <div class="main">
     <div class="container header">
       <div class="content header-content">
-        <%= image_tag("logodraft.png") %>
-        <h1 class="main-header">$Seksityö</h1>
+        <%= image_tag("logoplaceholder.png") %>
+        <h1 class="main-header">Nimi</h1>
       </div>
     </div>
     <div class="container container1">
@@ -39,7 +39,11 @@
             1. User does stuff
           </div>
           <div>
-            <%= image_tag("entry_screen_revised.png") %>
+            <div class="frame-holder">
+              <div class="frame-overlay"></div>
+              <iframe scrolling="no" align="middle" class="frame" src="/meetings/new"></iframe>
+
+            </div>
           </div>
         </div>
         <div class="img-container">
@@ -47,7 +51,10 @@
               2. Other stuff happens
           </div>
           <div>
-            <%= image_tag("status_screen_revised.png") %>
+            <div class="frame-holder">
+              <div class="frame-overlay"></div>
+              <iframe scrolling="no" align="middle" class="frame" src="/statusdemo"></iframe>
+            </div>
           </div>
         </div>
       </div>
@@ -55,7 +62,7 @@
 
   </div>
   <div class="footer">
-    <%= link_to '$Seksityö', root_path %>
+    <%= link_to 'Link to demo', root_path %>
   </div>
 </body>
 </html>

--- a/app/views/meetings/show.html.erb
+++ b/app/views/meetings/show.html.erb
@@ -12,7 +12,7 @@
 
 <div class="actions">
   <%= button_to "I'm OK", {id: @meeting.id}, class: 'submitbutton' %>
-  <%= button_to "Send Alert!", {action: "send_alert", id: @meeting.id}, class: 'alertbutton' %>
+  <%= button_to "Send Alert!", {action: "send_alert", id: @meeting.id, controller:"meetings"}, class: 'alertbutton' %>
 </div>
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   # Used by the info page iframe to simulate status page, uses the same template as the real status page.
   get 'statusdemo' => 'info#statusdemo'
 
+  get 'creationdemo' => 'info#creationdemo'
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
 
   get 'about' => 'info#about'
 
+  # Used by the info page iframe to simulate status page, uses the same template as the real status page.
+  get 'statusdemo' => 'info#statusdemo'
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
- Removed logo and seksityö-references
- Replaced static demo images with iframes that point to the app itself
- Added a new route and controller method to the info page that simulates the status page and creates a temporary meeting (that is not saved to the db) at /statusdemo
- Iframes have transparent divs on top to prevent user interaction
- Added reference to the meetings controller on the alert button to enable compability with the iframe (does not affect normal functionality)