### PR TITLE
Forced reload after changing language.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,8 @@ switchLanguage = function() {
     } else {
         document.cookie = "lang=en";
     }
+
+    location.reload();
 };
 
 /*

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -143,11 +143,6 @@ class MeetingsController < ApplicationController
     @meeting = Meeting.find_by_hashkey(cookies['current_meeting'])
   end
 
-
-  def extract_locale_from_accept_language_header
-    request.env['HTTP_ACCEPT_LANGUAGE'].scan(/^[a-z]{2}/).first
-  end
-
   # Never trust parameters from the scary internet, only allow the white list through.
   def meeting_params
     params.require(:meeting).permit(:nickname, :phone_number, :duration, :confirmed, :latitude, :longitude)

--- a/spec/controllers/meeting_controller_spec.rb
+++ b/spec/controllers/meeting_controller_spec.rb
@@ -70,6 +70,11 @@ RSpec.describe MeetingsController, type: :controller do
         get :new
         expect(response.body).to_not  have_content("English")
       end
+      it "has no language selector if preferred language is the default language" do
+        @request.env['HTTP_ACCEPT_LANGUAGE'] = "en"
+        get :new
+        expect(response.body).to_not have_content("English")
+      end
     end
     it "renders status page if hash found in cookies and database" do
       @meeting = Meeting.create(nickname: "Matti", phone_number: "0401231234", duration: 20)


### PR DESCRIPTION
Forced reload after changing language, because otherwise javascript breaks. Removed obsolete controller method and added test case to check language link visibility when the preferred language is also the default language.